### PR TITLE
Ignore Certificate Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,26 @@ Always enjoy feedback and suggestions.
 
 Help
 ====
-<pre>$  ./tilde_enum.py -h
+<pre>$ ./tilde_enum.py --help
 usage: tilde_enum.py [-h] [-c COOKIES] [-d DIRWORDLIST] [-f] [-p PROXY]
                      [-s SNOOZE] [-u URL] [-v] [-w WORDLIST]
+                     [--no-check-certificate]
 
 Exploits and expands the file names found from the tilde enumeration vuln
 
 optional arguments:
-  -h, --help      show this help message and exit
-  -c COOKIES      cookies to be used in the request
-  -d DIRWORDLIST  an optional wordlist for directory name content
-  -f              force testing of the server even if the headers do not
-                  report it as an IIS system
-  -p PROXY        Use a proxy host:port
-  -s SNOOZE       time in seconds to sleep/wait between requests
-  -u URL          URL to scan
-  -v              verbose output
-  -w WORDLIST     the word list to be used for guessing files
+  -h, --help            show this help message and exit
+  -c COOKIES            cookies to be used in the request
+  -d DIRWORDLIST        an optional wordlist for directory name content
+  -f                    force testing of the server even if the headers do not
+                        report it as an IIS system
+  -p PROXY              Use a proxy host:port
+  -s SNOOZE             time in seconds to sleep/wait between requests
+  -u URL                URL to scan
+  -v                    verbose output
+  -w WORDLIST           the word list to be used for guessing files
+  --no-check-certificate
+                        don't verify the SSL certificate
 </pre>
 
 

--- a/tilde_enum.py
+++ b/tilde_enum.py
@@ -17,6 +17,7 @@ import random
 import string
 import itertools
 import urllib2
+import ssl
 from urlparse import urlparse
 from time import sleep
 
@@ -51,6 +52,9 @@ chars = 'abcdefghijklmnopqrstuvwxyz1234567890-_'
 # Response codes - user and error
 response_code = {}
 
+# SSL context
+ssl_ctx = ssl.create_default_context()
+
 
 #=================================================
 # Functions & Classes
@@ -72,10 +76,12 @@ def getWebServerResponse(url):
         req = urllib2.Request(url, None, headers)
         if args.cookies:
             req.add_header("Cookie", args.cookies)
-        response = urllib2.urlopen(req)
+        response = urllib2.urlopen(req, context=ssl_ctx)
         return response
     except urllib2.URLError as e:
         return e
+    except ssl.CertificateError as e:
+        sys.exit(bcolors.RED + '[!]  SSL Certificate Error: try running again with --no-check-certificate' + bcolors.ENDC)
     except Exception as e:
         return 0
 
@@ -598,6 +604,7 @@ parser.add_argument('-s', dest='snooze', default=0, type=float, help='time in se
 parser.add_argument('-u', dest='url', help='URL to scan')
 parser.add_argument('-v', action='store_true', default=False, help='verbose output')
 parser.add_argument('-w', dest='wordlist', help='the word list to be used for guessing files')
+parser.add_argument('--no-check-certificate', action='store_true', help='don\'t verify the SSL certificate')
 args = parser.parse_args()
 
 # COLORIZATION OF OUTPUT
@@ -653,5 +660,9 @@ if args.proxy:
 
 if args.v:
     print bcolors.PURPLE + '[-]  Entering "Verbose Mode"....brace yourself for additional information.' + bcolors.ENDC
+
+if args.no_check_certificate:
+    ssl_ctx.check_hostname = False
+    ssl_ctx.verify_mode = ssl.CERT_NONE
 
 if __name__ == "__main__": main()


### PR DESCRIPTION
I was using this on a test recently and realized the script wasn't handling certificate issues (ie: self-signed certs).

I added the `--no-check-certificate` option (option name borrowed from `wget`). Setting this option will configure the SSL context to not verify the cert.

If this option is not set, and there is a cert issue, the script will print out a descriptive error message and suggest the use of `--no-check-certificate`.